### PR TITLE
fix mingw

### DIFF
--- a/include/taichi/dynamics/rigid_body.h
+++ b/include/taichi/dynamics/rigid_body.h
@@ -348,8 +348,13 @@ struct RigidBody {
     }
     TC_STATIC_ELSE {
 #ifdef _WIN64
+#ifdef _MSVC_LANG
       this->inv_inertia =
           inversed(id(inertia).cast<float64>()).cast<real>();
+#else
+      this->inv_inertia =
+          inversed(id(inertia).template cast<float64>()).template cast<real>();
+#endif
 #else
       this->inv_inertia =
           inversed(id(inertia).template cast<float64>()).template cast<real>();

--- a/include/taichi/system/threading.h
+++ b/include/taichi/system/threading.h
@@ -106,7 +106,8 @@ class PID {
 #ifdef _MSVC_LANG
     TC_NOT_IMPLEMENTED
 #else
-    return (int)getppid();
+    TC_NOT_IMPLEMENTED
+//    return (int)getppid();
 #endif
   }
 };


### PR DESCRIPTION
No more grammar errors

```
"D:\CLion 2017.3.2\bin\cmake\bin\cmake.exe" --build D:\repos\taichi\cmake\Debug --target taichi_core -- -j 2
mingw32-make.exe[3]: *** No rule to make target '../../external/lib/embree.lib', needed by '../../runtimes/libtaichi_core.dll'.  Stop.
mingw32-make.exe[2]: *** [CMakeFiles\Makefile2:67: CMakeFiles/taichi_core.dir/all] Error 2
mingw32-make.exe[1]: *** [CMakeFiles\Makefile2:79: CMakeFiles/taichi_core.dir/rule] Error 2
mingw32-make.exe: *** [Makefile:117: taichi_core] Error 2

```