### PR TITLE
Fix density array size for volume rendering example

### DIFF
--- a/examples/volume_renderer.py
+++ b/examples/volume_renderer.py
@@ -37,7 +37,7 @@ loss = scalar()
 
 @ti.layout
 def place():
-  ti.root.dense(ti.ijk, res).place(density)
+  ti.root.dense(ti.ijk, density_res).place(density)
   ti.root.dense(ti.l, n_views).dense(ti.ij, res).place(target_images, images)
   ti.root.place(loss)
   ti.root.lazy_grad()


### PR DESCRIPTION
Density array should be [density_res x density_res x density_res], not [res x res x res] (as `res` is the image resolution and `density_res` is the resolution of the density array).