### PR TITLE
Update to g++-7

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -299,7 +299,7 @@ std::string CompileConfig::compiler_config() {
         "{}/include -I/usr/local/cuda/include/ -ccbin {} "
         " -lstdc++ {} {} "
         "-DTLANG_GPU {} ",
-        gcc_opt_flag(), get_repo_dir(), "g++-6", include_flag, linking,
+        gcc_opt_flag(), get_repo_dir(), "g++-7", include_flag, linking,
         extra_flags);
   }
   return cmd;


### PR DESCRIPTION
README instructs user to install g++-7 but util.cpp invokes g++-6.